### PR TITLE
WebRouter CodePipeline DockerHub login

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ Based on the results of load testing we might want to switch ECS to ALBRequestCo
 to keep ~500-600 connections to each NGINX container which is well under the 1024 maximum NGINX is currently set to.  
 This should only be done if load testing shows that this version does not work properly.
 
+## DockerHub login
+
+We store the DockerHub username and password as a secret in AWS Secrets Manager.  There is one secret per account and you can check
+if the secret is present by doing the following command - if you get the error shown then it doesn't exist:
+
+```bash
+$ aws --profile x secretsmanager get-secret-value --secret-id websites-webrouter/dockerhub-credentials --query SecretString
+aws --profile websites-prod secretsmanager get-secret-value  --secret-id  websites-webrouter-dockerhub-secret --query SecretString
+
+An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret.
+```
+
+You can create a secret by creating a JSON file similar to `sample-secret.json` and doing the following command:
+
+```bash
+$ aws --profile x secretsmanager create-secret --name websites-webrouter/dockerhub-credentials --secret-string file://dockerhub.json
+{
+    "ARN": "arn:aws:secretsmanager:us-east-1:acctid:secret:websites-webrouter/dockerhub-credentials-RAnCED",
+    "Name": "websites-webrouter/dockerhub-credentials",
+    "VersionId": "4a2ea896-8ca4-420c-9b93-fa96e13e9609"
+}
+```
 
 ## Setting up a new landscape
 

--- a/iam-landscape/main.yaml
+++ b/iam-landscape/main.yaml
@@ -13,6 +13,10 @@ Parameters:
       This prefix is used to link the project stuff to the VPC that it lives in.  It is used as part of the 
       export and import values from other stacks.  
     Type: String
+  DockerCredentialsName:
+    Description: "Name for the DockerHub secret in SecretsManager"
+    Type: String
+    Default: "websites-webrouter-dockerhub-secret"
 Resources:
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -196,6 +200,12 @@ Resources:
                   - ecr:InitiateLayerUpload
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload
+              - Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${DockerCredentialsName}*"
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - secretsmanager:GetSecretValue
+
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role

--- a/iam-landscape/main.yaml
+++ b/iam-landscape/main.yaml
@@ -16,7 +16,7 @@ Parameters:
   DockerCredentialsName:
     Description: "Name for the DockerHub secret in SecretsManager"
     Type: String
-    Default: "websites-webrouter-dockerhub-secret"
+    Default: "websites-webrouter/dockerhub-credentials"
 Resources:
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/sample-secret.json
+++ b/sample-secret.json
@@ -1,0 +1,4 @@
+{
+  "user":"username",
+  "password":"password"
+}


### PR DESCRIPTION
This adjusts the permissions of the CodeBuild role so builds can read the AWS secret which contains the DockerHub username and password.  

It also includes instructions on how to check whether there is already an AWS secret and how to create one if it does not already exist.  Note: I have already created the secret in the buaws-websites-nonprod (web2cloud-nonprod) account but not in the buaws-websites-prod account.  It is the same username/password for both accounts but they are different AWS secrets.

There is a 3-step process to deploy this to existing instances:
1) Confirm that the username/password AWS secret already exists in the account.  
2) Update the iam-landscape stack for the landscape - for example, update buaws-webrouter-iam-test for the test landscape.
3) Update the buildspec.yml to login into DockerHub during the pre_build stage.  There is a pull request in webrouter-nonprod which shows the change.  The same change should be done for all landscapes.


